### PR TITLE
Update submodule url for easy cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "BitcoinUnlimited"]
 	path = BitcoinUnlimited
-	url = https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
+	url = git@github.com:BitcoinUnlimited/BitcoinUnlimited.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "BitcoinUnlimited"]
 	path = BitcoinUnlimited
-	url = git@github.com:BitcoinUnlimited/BitcoinUnlimited.git
+	url = https://github.com/BitcoinUnlimited/BitcoinUnlimited.git

--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ Txunami stores all wallet state in RAM and just quits when done -- **all of the 
 Txunami uses Bitcoin Unlimited's libbitcoincash.so and libunivalue.a shared libraries.  Therefore it is necessary to first build Bitcoin Unlimited.  Bitcoin Unlimited has been added as a submodule so to check it out use:
 ```git submodule update --init --recursive```
 
-It is then necessary to build BitcoinUnlimited with the "--enable-shared" flag set in configure.  Please read https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/release/doc/build-unix.md for more details.
+It is then necessary to build BitcoinUnlimited with the "--enable-shared" flag set in configure.  Please read https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/release/doc/build-unix.md for more details. For most purposes, the build process will look like this: 
 
+```
+cd BitcoinUnlimited
+git checkout dev  # Optional - checkout the latest enchancements; if that doesn't work, swap "dev" for "release"
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+./autogen.sh
+./configure --disable-wallet --with-gui=no --enable-shared
+make
+```
+
+To speed up make, you can run parallel compilation with the `-j N` flag, where N is the number of threads you want (put in your number of cores-1 for a safe default)
 
 If you have a separate Bitcoin Unlimited build directory, you can choose to not use the submodule.  Instead edit txunami/Makefile and change the BU_DIR variable to point to your Bitcoin Unlimited build source directory, or override BU_DIR on the make command line.  For example, If you are doing an "in-source-tree" build, this directory is "BitcoinUnlimited/src", but if you ran an "out-of-source-tree" build, say into the "BitcoinUnlimited/release" subdirectory, this directory is "BitcoinUnlimited/release/src".  
 


### PR DESCRIPTION
The current .gitmodules file references a "git@..." url, which is valid, but requires authentication (SSH keys, which require to create an account and to associate a key). This is cumbersome for people that don't have an account, or for compiling on short lived servers. 

This change will let people use the indicated `git submodule update --init --recursive` command with no issue, even without proper credentials set. 

NB: This will not work on repositories that were already cloned, because the url from .gitmodules is copied over to a section in .git/config. In such setups the link should be updated manually (but those people probably have it working already)