### PR TITLE
Update submodule url for easy cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "BitcoinUnlimited"]
 	path = BitcoinUnlimited
-	url = git@github.com:BitcoinUnlimited/BitcoinUnlimited.git
+	url = https://github.com/BitcoinUnlimited/BitcoinUnlimited.git


### PR DESCRIPTION
The current .gitmodules file references a "git@..." url, which is valid, but requires authentication (SSH keys, which require to create an account and to associate a key). This is cumbersome for people that don't have an account, or for compiling on short lived servers.

This change will let people use the indicated git submodule update --init --recursive command with no issue, even without proper credentials set.

NB: This will not work on repositories that were already cloned, because the url from .gitmodules is copied over to a section in .git/config. In such setups the link should be updated manually (but those people probably have it working already)