### PR TITLE
Update include paths in Makefile

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "BitcoinUnlimited"]
 	path = BitcoinUnlimited
-	url = https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
+	url = git@github.com:BitcoinUnlimited/BitcoinUnlimited.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "BitcoinUnlimited"]
 	path = BitcoinUnlimited
-	url = git@github.com:BitcoinUnlimited/BitcoinUnlimited.git
+	url = https://github.com/BitcoinUnlimited/BitcoinUnlimited.git

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 BU_DIR=./BitcoinUnlimited/src
 
-INC_PATHS:=-I$(BU_DIR)/../../src/univalue/include -I$(BU_DIR)/../../src/cashlib -I$(BU_DIR)/../../src -I$(BU_DIR) -I$(BU_DIR)/config
+INC_PATHS:=-I$(BU_DIR)/../src/univalue/include -I$(BU_DIR)/../src/cashlib -I$(BU_DIR)/../src -I$(BU_DIR) -I$(BU_DIR)/config
 LIB_PATHS:=-L. -L$(BU_DIR)/.libs -L$(BU_DIR)/univalue/.libs
 
 STD_LIBS:=-lboost_system -lpthread

--- a/README.md
+++ b/README.md
@@ -15,8 +15,18 @@ Txunami stores all wallet state in RAM and just quits when done -- **all of the 
 Txunami uses Bitcoin Unlimited's libbitcoincash.so and libunivalue.a shared libraries.  Therefore it is necessary to first build Bitcoin Unlimited.  Bitcoin Unlimited has been added as a submodule so to check it out use:
 ```git submodule update --init --recursive```
 
-It is then necessary to build BitcoinUnlimited with the "--enable-shared" flag set in configure.  Please read https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/release/doc/build-unix.md for more details.
+It is then necessary to build BitcoinUnlimited with the "--enable-shared" flag set in configure.  Please read https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/release/doc/build-unix.md for more details. For most purposes, the build process will look like this: 
 
+```
+cd BitcoinUnlimited
+git checkout dev  # Optional - checkout the latest enchancements; if that doesn't work, swap "dev" for "release"
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
+./autogen.sh
+./configure --disable-wallet --with-gui=no --enable-shared
+make
+```
+
+To speed up make, you can run parallel compilation with the `-j N` flag, where N is the number of threads you want (put in your number of cores-1 for a safe default)
 
 If you have a separate Bitcoin Unlimited build directory, you can choose to not use the submodule.  Instead edit txunami/Makefile and change the BU_DIR variable to point to your Bitcoin Unlimited build source directory, or override BU_DIR on the make command line.  For example, If you are doing an "in-source-tree" build, this directory is "BitcoinUnlimited/src", but if you ran an "out-of-source-tree" build, say into the "BitcoinUnlimited/release" subdirectory, this directory is "BitcoinUnlimited/release/src".  
 


### PR DESCRIPTION
For the default instructions, the dependencies are in the directory `BitcoinUnlimited/src`.

The Makefile sets `BU_DIR=./BitcoinUnlimited/src`, but then goes two dirs up from there for the include paths. Only one dir up is correct in the default set up. 

I think this might be a vestige of a "release" compilation, but no instructions for that are provided. 

I have tested this to work on my machine, cloning, compiling BU and compiling txunami. 