### PR TITLE
Wait for <enter> on scheduled

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -779,7 +779,7 @@ int main(int argc, char** argv)
     
     printf("done in %f4.2 sec\n", ((float)(end-start))/1000000000.0);
     printf("create tx loop in %6.2f sec\n", ((float)(end-createTxLoopStart))/1000000000.0);
-    printf("Generate a block <enter>\n");
+    printf("Generate a block and press <enter>\n");
     string input;
     getline(cin, input);
 

--- a/main.cpp
+++ b/main.cpp
@@ -779,6 +779,9 @@ int main(int argc, char** argv)
     
     printf("done in %f4.2 sec\n", ((float)(end-start))/1000000000.0);
     printf("create tx loop in %6.2f sec\n", ((float)(end-createTxLoopStart))/1000000000.0);
+    printf("Generate a block <enter>\n");
+    string input;
+    getline(cin, input);
 
     txo = utxo;  // Copy the vector to send to myself
 
@@ -794,12 +797,7 @@ int main(int argc, char** argv)
     if (runAschedule)
         sched.Execute(utxo, txo);
     else
-    {
-        printf("Generate a block <enter>\n");
-        string input;
-        cin >> input;
         MaxSpeed(gc.bitcoind, utxo, txo);
-    }
 
 }
 


### PR DESCRIPTION
The "wait for enter" is a great feature that works in the undocumented MaxSpeed mode. It is useful to have it in the scheduled mode too, so that one can start generating transactions when she is ready, instead of waiting for a predefined delay.

I also clarified the message a little bit.

Let me know what you think.
