### PR TITLE
Save remaining utxos in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ It then spawns a thread for every schedule entity.  The thread sleeps until the 
 
 It uses a leaky bucket algorithm to precisely control the rate of transaction generation.  When the end time specified in the schedule entity is reached, the connection is disconnected and the thread quits.  When all threads quit, the run is complete and Txunami ends.
 
-At this point, there is no way to recover any funds left in UTXOs.  If needed, it would not be too hard to either write all these UTXOs to disk, or implement a UTXO sweep phase that combines all this dust back into a few UTXOs sent to addresses in the configuration file.
+After all phases end correctly, the remaining UTXOs will be written to the file `utxos.json`. If the remaining balance is significant, it is easy to copy-paste the contents of this file back to the `coins` section of `txunami.json` to continue spending; otherwise the private keys can be swept. 
 

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@
 #include "random.h"
 #include "utilstrencodings.h"
 #include "leakybucket.h"
+#include "cashaddrenc.h"
 
 using namespace std;
 
@@ -816,6 +817,9 @@ bool saveUtxos(std::vector<UTXO> utxos)
         entry.pushKV("satoshi", utxo.satoshi);
         CScript script = utxo.constraintScript;
         entry.pushKV("scriptPubKey", HexStr(script.begin(), script.end()));
+        CTxDestination address;
+        ExtractDestination(script, address);
+        entry.pushKV("address", EncodeCashAddr(address, Params()));        
         entry.pushKV("privKey", CBitcoinSecret(utxo.privKey).ToString());
         results.push_back(entry);
     }


### PR DESCRIPTION
At the end of a successful run an attempt to save the remaining utxos is made in utxos.json file. This will not work if the run is interrupted. 

The new utxos can be simply copy-pasted to the txunami.json configuration file. 

A small off-by-one bug is corrected: if the number of utxos read was already equal to the desired number of utxos, the old code would still cycle once. WIth this fix the preparation phase can be skipped entirely if the number of utxos read is already sufficient. 

